### PR TITLE
Feat add jinja2 templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     * .github/ISSUE_TEMPLATE/config.yml
     * README.md
     * CHANGELOG.md
+    * CODE_OF_CONDUCT.md
 
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 * Implement jinja2 templating for
     * .github/ISSUE_TEMPLATE/bug.yml
     * .github/ISSUE_TEMPLATE/feature_request.yml
+    * .github/ISSUE_TEMPLATE/config.yml
     * README.md
+    * CHANGELOG.md
 
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v2.0.0
 * Moved Readme creation to default files Generates
 * Changed `-r` argument to repo name
 * Added repo name to README.md templating

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
     * CHANGELOG.md
     * CODE_OF_CONDUCT.md
     * SECURITY.md
+    * CONTRIBUTING.md
 
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     * SECURITY.md
     * CONTRIBUTING.md
     * SUPPORT.md
+    * .github/PULL_REQUEST_TEMPLATE.md
 
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * Added repo name to README.md templating
 * Added jinja2 package to requirements.txt
 * Implement jinja2 templating for
-    * .githun/ISSUE_TEMPLATE/bug.yml
+    * .github/ISSUE_TEMPLATE/bug.yml
+    * .github/ISSUE_TEMPLATE/feature_request.yml
 
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+* Moved Readme creation to default files Generates
+* Changed `-r` argument to repo name
+* Added repo name to README.md templating
+* Added jinja2 package to requirements.txt
+* Implement jinja2 templating for
+    * .githun/ISSUE_TEMPLATE/bug.yml
+
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo
 * Updated `README.md` to use Badging for whatever license the Repo is configured to use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     * CONTRIBUTING.md
     * SUPPORT.md
     * .github/PULL_REQUEST_TEMPLATE.md
+    * CODEOWNERS.md
 
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     * CODE_OF_CONDUCT.md
     * SECURITY.md
     * CONTRIBUTING.md
+    * SUPPORT.md
 
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     * README.md
     * CHANGELOG.md
     * CODE_OF_CONDUCT.md
+    * SECURITY.md
 
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Implement jinja2 templating for
     * .github/ISSUE_TEMPLATE/bug.yml
     * .github/ISSUE_TEMPLATE/feature_request.yml
+    * README.md
 
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     * SUPPORT.md
     * .github/PULL_REQUEST_TEMPLATE.md
     * CODEOWNERS.md
+* Wrapped main logic in try/except statement to write Exceptions to log file
 
 # v1.1.0
 * Added `-l`, `--license` option to generate a `LICENSE.md` file in the root of the repo

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ It is recommended to use a Python virtual environment to run this to ensure you 
 
 For the full help of this script please run `./bootstrap_repo.py -h`
 
-For most cases you can simply run `./bootstrap_repo.py -r True -o my-organization-name`
+For most cases you can simply run `./bootstrap_repo.py -r my-repo-name -o my-organization-name -l MIT`
                  

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 - [X] README.md
 - [ ] CODEOWNERS.md
 - [X] CODE_OF_CONDUCT.md
-- [ ] CONTRIBUTING.md
+- [X] CONTRIBUTING.md
 - [X] SECURITY.md
 - [ ] SUPPORT.md
 - [X] CHANGELOG.md

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 ## Refactor File creation based on Jinja2 templating
 ### Default Files
 - [X] README.md
-- [ ] CODEOWNERS.md
+- [X] CODEOWNERS.md
 - [X] CODE_OF_CONDUCT.md
 - [X] CONTRIBUTING.md
 - [X] SECURITY.md

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,12 @@
 ## Refactor File creation based on Jinja2 templating
 ### Default Files
-- [] README.md
-- [] CODEOWNERS.md
-- [] CODE_OF_CONDUCT.md
-- [] CONTRIBUTING.md
-- [] SECURITY.md
-- [] SUPPORT.md
-- [] .github/PULL_REQUEST?TEMPLATE.md
-- [] .github/ISSUE_TEMPLATE/bug.yml
-- [] .github/ISSUE_TEMPLATE/feature_request.yml
-- [] .github/ISSUE_TEMPLATE/config.yml
+- [ ] README.md
+- [ ] CODEOWNERS.md
+- [ ] CODE_OF_CONDUCT.md
+- [ ] CONTRIBUTING.md
+- [ ] SECURITY.md
+- [ ] SUPPORT.md
+- [ ] .github/PULL_REQUEST?TEMPLATE.md
+- [ ] .github/ISSUE_TEMPLATE/bug.yml
+- [ ] .github/ISSUE_TEMPLATE/feature_request.yml
+- [ ] .github/ISSUE_TEMPLATE/config.yml

--- a/TODO.md
+++ b/TODO.md
@@ -8,5 +8,5 @@
 - [ ] SUPPORT.md
 - [ ] .github/PULL_REQUEST?TEMPLATE.md
 - [X] .github/ISSUE_TEMPLATE/bug.yml
-- [ ] .github/ISSUE_TEMPLATE/feature_request.yml
+- [X] .github/ISSUE_TEMPLATE/feature_request.yml
 - [ ] .github/ISSUE_TEMPLATE/config.yml

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,8 @@
 - [ ] CONTRIBUTING.md
 - [ ] SECURITY.md
 - [ ] SUPPORT.md
+- [X] CHANGELOG.md
 - [ ] .github/PULL_REQUEST_TEMPLATE.md
 - [X] .github/ISSUE_TEMPLATE/bug.yml
 - [X] .github/ISSUE_TEMPLATE/feature_request.yml
-- [ ] .github/ISSUE_TEMPLATE/config.yml
+- [X] .github/ISSUE_TEMPLATE/config.yml

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 ### Default Files
 - [X] README.md
 - [ ] CODEOWNERS.md
-- [ ] CODE_OF_CONDUCT.md
+- [X] CODE_OF_CONDUCT.md
 - [ ] CONTRIBUTING.md
 - [ ] SECURITY.md
 - [ ] SUPPORT.md

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,1 @@
-* Add option to select a License and generate a LICENSE.md file in the root of the repo
+* Refactor File creation based on Jinja2 templating

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 - [X] SECURITY.md
 - [X] SUPPORT.md
 - [X] CHANGELOG.md
-- [ ] .github/PULL_REQUEST_TEMPLATE.md
+- [X] .github/PULL_REQUEST_TEMPLATE.md
 - [X] .github/ISSUE_TEMPLATE/bug.yml
 - [X] .github/ISSUE_TEMPLATE/feature_request.yml
 - [X] .github/ISSUE_TEMPLATE/config.yml

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 - [ ] CODEOWNERS.md
 - [X] CODE_OF_CONDUCT.md
 - [ ] CONTRIBUTING.md
-- [ ] SECURITY.md
+- [X] SECURITY.md
 - [ ] SUPPORT.md
 - [X] CHANGELOG.md
 - [ ] .github/PULL_REQUEST_TEMPLATE.md

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 - [X] CODE_OF_CONDUCT.md
 - [X] CONTRIBUTING.md
 - [X] SECURITY.md
-- [ ] SUPPORT.md
+- [X] SUPPORT.md
 - [X] CHANGELOG.md
 - [ ] .github/PULL_REQUEST_TEMPLATE.md
 - [X] .github/ISSUE_TEMPLATE/bug.yml

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,6 @@
 - [ ] SECURITY.md
 - [ ] SUPPORT.md
 - [ ] .github/PULL_REQUEST?TEMPLATE.md
-- [ ] .github/ISSUE_TEMPLATE/bug.yml
+- [X] .github/ISSUE_TEMPLATE/bug.yml
 - [ ] .github/ISSUE_TEMPLATE/feature_request.yml
 - [ ] .github/ISSUE_TEMPLATE/config.yml

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,12 @@
 * Refactor File creation based on Jinja2 templating
+    * Default Files
+        - [] README.md
+        - [] CODEOWNERS.md
+        - [] CODE_OF_CONDUCT.md
+        - [] CONTRIBUTING.md
+        - [] SECURITY.md
+        - [] SUPPORT.md
+        - [] .github/PULL_REQUEST?TEMPLATE.md
+        - [] .github/ISSUE_TEMPLATE/bug.yml
+        - [] .github/ISSUE_TEMPLATE/feature_request.yml
+        - [] .github/ISSUE_TEMPLATE/config.yml

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,12 @@
-* Refactor File creation based on Jinja2 templating
-    * Default Files
-        - [] README.md
-        - [] CODEOWNERS.md
-        - [] CODE_OF_CONDUCT.md
-        - [] CONTRIBUTING.md
-        - [] SECURITY.md
-        - [] SUPPORT.md
-        - [] .github/PULL_REQUEST?TEMPLATE.md
-        - [] .github/ISSUE_TEMPLATE/bug.yml
-        - [] .github/ISSUE_TEMPLATE/feature_request.yml
-        - [] .github/ISSUE_TEMPLATE/config.yml
+## Refactor File creation based on Jinja2 templating
+### Default Files
+- [] README.md
+- [] CODEOWNERS.md
+- [] CODE_OF_CONDUCT.md
+- [] CONTRIBUTING.md
+- [] SECURITY.md
+- [] SUPPORT.md
+- [] .github/PULL_REQUEST?TEMPLATE.md
+- [] .github/ISSUE_TEMPLATE/bug.yml
+- [] .github/ISSUE_TEMPLATE/feature_request.yml
+- [] .github/ISSUE_TEMPLATE/config.yml

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,12 @@
 ## Refactor File creation based on Jinja2 templating
 ### Default Files
-- [ ] README.md
+- [X] README.md
 - [ ] CODEOWNERS.md
 - [ ] CODE_OF_CONDUCT.md
 - [ ] CONTRIBUTING.md
 - [ ] SECURITY.md
 - [ ] SUPPORT.md
-- [ ] .github/PULL_REQUEST?TEMPLATE.md
+- [ ] .github/PULL_REQUEST_TEMPLATE.md
 - [X] .github/ISSUE_TEMPLATE/bug.yml
 - [X] .github/ISSUE_TEMPLATE/feature_request.yml
 - [ ] .github/ISSUE_TEMPLATE/config.yml

--- a/bootstrap_repo.py
+++ b/bootstrap_repo.py
@@ -171,14 +171,11 @@ def generate_default_files(logger, org, lic, repo):
     c.write(contrib_content)        
     c.close()
 
+  support_template = environment.get_template("support.jinja2")
+  support_vars = {}
+  support_content = support_template.render(support_vars)
   with open("output/SUPPORT.md", "w") as support:
-    support.write("""
-# Support
-
-## How to file issues and get help  
-
-This project uses [GitHub issues][gh-issue] to [track bugs][gh-bug] and [feature requests][gh-feature]. Please search the existing issues before filing new issues to avoid duplicates. For new topics, file your bug or feature request as a new issue.
-""")
+    support.write(support_content)
     support.close()
 
   with open("output/.github/PULL_REQUEST_TEMPLATE.md", "w") as prt:

--- a/bootstrap_repo.py
+++ b/bootstrap_repo.py
@@ -186,12 +186,11 @@ We prefer all communications to be in English.
              """)
     s.close()
 
+  coc_template = environment.get_template("code_of_conduct.jinja2")
+  coc_vars = {}
+  coc_content = coc_template.render(coc_vars)
   with open("output/CODE_OF_CONDUCT.md", "w") as cc:
-    cc.write("""
-# Code of Conduct
-
-Be nice and respectful.
-             """)
+    cc.write(coc_content)
     cc.close()
 
   with open("output/CONTRIBUTING.md", "w") as c:

--- a/bootstrap_repo.py
+++ b/bootstrap_repo.py
@@ -133,22 +133,19 @@ def generate_default_files(logger, org, lic, repo):
   generate_readme(org, lic, repo)
 
   l.write_log("info", "Creating output/CHANGELOG.md")
+  changelog_template = environment.get_template("changelog.jinja2")
+  changelog_vars = {}
+  changelog_content = changelog_template.render(changelog_vars)
   with open("output/CHANGELOG.md", "w") as cl:
-    cl.write("""
-# Unreleased
-* initial repo creation
-             """)
+    cl.write(changelog_content)
     cl.close()
 
   l.write_log("info", "Creating output/.github/ISSUE_TEMPLATE/config.yml")
+  ic_template = environment.get_template("issue_config.jinja2")
+  ic_vars = {}
+  ic_content = ic_template.render(ic_vars)
   with open("output/.github/ISSUE_TEMPLATE/config.yml", "w") as ic:
-    ic.write("""
-blank_issues_enabled: false
-contact_links:
-  - name: GitHub Support
-    url: https://support.github.com/contact
-    about: Contact Support if you're having trouble with your GitHub account.
-             """)
+    ic.write(ic_content)
     ic.close()
 
   with open("output/SECURITY.md", "w") as s:

--- a/bootstrap_repo.py
+++ b/bootstrap_repo.py
@@ -178,23 +178,11 @@ def generate_default_files(logger, org, lic, repo):
     support.write(support_content)
     support.close()
 
+  pr_template = environment.get_template("pull_request_template.jinja2")
+  pr_vars = {}
+  pr_content = pr_template.render(pr_vars)
   with open("output/.github/PULL_REQUEST_TEMPLATE.md", "w") as prt:
-    prt.write("""
-## Summary of the Pull Request
-
-## References and Relevant Issues
-
-## Detailed Description of the Pull Request / Additional comments
-
-## Validation Steps Performed
-
-## PR Checklist
-- [ ] Closes #xxx
-- [ ] Tests added/passed
-- [ ] Documentation updated
-   - If checked, please file a pull request and link it here: #xxx
-- [ ] Schema updated (if necessary)
-             """)
+    prt.write(pr_content)
     prt.close()
 
   with open("output/CODEOWNERS.md", "w") as co:

--- a/bootstrap_repo.py
+++ b/bootstrap_repo.py
@@ -86,96 +86,22 @@ def generate_bug_template(logger, org):
   bug_vars = {
     "org": org,
   }
-  content = bug_template.render(bug_vars)
+  bug_content = bug_template.render(bug_vars)
   with open("output/.github/ISSUE_TEMPLATE/bug.yml", "w") as bug:
-    bug.write(content)
-#     bug.write("""
-# name: 🐛Bug Report
-# description: File a bug report here
-# title: "[BUG]: "
-# labels: ["bug"]
-# assignees: ["<My Github Username>"]
-# body:
-#   - type: markdown
-#     attributes:
-#       value: |
-#         Thanks for taking the time to fill out this bug report!!!
-#   - type: checkboxes
-#     id: new-bug
-#     attributes:
-#       label: Is there an existing issue for this?
-#       description: Please search to see if an issue already exists for the bug you encountered.
-#       options:
-#       - label: I have searched the existing issues
-#         required: true
-#   - type: textarea
-#     id: bug-description
-#     attributes:
-#       label: Description of the bug
-#       description: Tell us what bug you encountered and what should have happened
-#     validations:
-#       required: true
-#   - type: textarea
-#     id: steps-to-reproduce
-#     attributes:
-#       label: Steps To Reproduce
-#       description: Steps to reproduce the behavior.
-#       placeholder: Please write the steps in a list form
-#     validations:
-#       required: true
-#   - type: dropdown
-#     id: versions
-#     attributes:
-#       label: Which version of the app are you using?
-#       description: If this issue is occurring on more than 1 version of the app, select the appropriate versions.
-#       multiple: true
-#       options:
-#        - 1.0.0
-#     validations:
-#       required: true
-#              """)
+    bug.write(bug_content)
     bug.close()
 
-def generate_feature_request_template(logger):
+def generate_feature_request_template(logger, org):
   l=logger
 
   l.write_log("info", "Creating output/.github/ISSUE_TEMPLATE/feature_request.yml")
+  feat_template = environment.get_template("feature_requests.jinja2")
+  feat_vars = {
+    "org": org,
+  }
+  feat_content = feat_template.render(feat_vars)
   with open("output/.github/ISSUE_TEMPLATE/feature_request.yml", "w") as feat:
-    feat.write("""
-name: 🚀Feature request
-description: Suggest and idea for improvement
-title: "[Feat]: "
-labels: ["Enhancement"]
-assignees: ["<My Github Username>"]
-body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to fill out this feature request!!!
-  - type: checkboxes
-    id: new-feature
-    attributes:
-      label: Is there an existing issue/feature for this?
-      description: Please search to see if an issue or feature request already exists for this.
-      options:
-      - label: I have searched the existing issues
-        required: true
-  - type: textarea
-    id: feature-description
-    attributes:
-      label: Description of the feature
-      description: Tell us what this feature is about and what it will do.
-    validations:
-      required: true
-  - type: textarea
-    id: value
-    attributes:
-      label: What value will this feature add?
-      description: Provide examples of what value will be added by implementing the feature.
-      placeholder: Please write the values in a list form
-    validations:
-      required: true
-             """)
+    feat.write(feat_content)
     feat.close()
 
 def generate_readme(org, lic, repo):
@@ -207,18 +133,9 @@ def generate_default_files(logger, org, lic, repo):
     os.makedirs("output/.github/ISSUE_TEMPLATE")
 
   generate_bug_template(l, org)
-  generate_feature_request_template(l)
+  generate_feature_request_template(l, org)
   l.write_log("info", "Generating README.md file")
   generate_readme(org, lic, repo)
-
-  # Path.touch("output/CHANGELOG.md")
-  # Path.touch("output/SUPPORT.md")
-  # Path.touch("output/SECURITY.md")
-  # Path.touch("output/CODE_OF_CONDUCT.md")
-  # Path.touch("output/CONTRIBUTING.md")
-  # Path.touch("output/CODEOWNERS.md")
-  # Path.touch("output/.github/ISSUE_TEMPLATE/config.yml")
-  # Path.touch("output/.github/PULL_REQUEST_TEMPLATE.md")
 
   l.write_log("info", "Creating output/CHANGELOG.md")
   with open("output/CHANGELOG.md", "w") as cl:

--- a/bootstrap_repo.py
+++ b/bootstrap_repo.py
@@ -148,42 +148,13 @@ def generate_default_files(logger, org, lic, repo):
     ic.write(ic_content)
     ic.close()
 
+  security_template = environment.get_template("security.jinja2")
+  security_vars = {
+    "org": org,
+  }
+  security_content = security_template.render(security_vars)
   with open("output/SECURITY.md", "w") as s:
-    s.write(f"""
-## Security
-
-{org} takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations.
-
-If you believe you have found a security vulnerability in any {org}-owned repository  please report it to us as described below.
-
-## Reporting Security Issues
-            
-To report a security related issue, please open an issue on this repository and describe the details using the following template
-
-```
-# Security Vulnerability Description
-
-## Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-            
-## References to any CVE's
-            
-## Advanced Details
-### Files with security vulnerability
-
-### Location of impacted source code (if known)
-
-### Steps to reproduce issue
-            
-### Proof of concept of exploitation (if possible)
-            
-## Impact of Vulnerability
-
-```
-            
-## Preferred Languages
-
-We prefer all communications to be in English.
-             """)
+    s.write(security_content)
     s.close()
 
   coc_template = environment.get_template("code_of_conduct.jinja2")
@@ -281,10 +252,6 @@ def main():
 
   l.write_log("info", "Generating Default Files")
   generate_default_files(l, args.organization, args.license, args.repo)
-
-  # if args.readme:
-  #   l.write_log("info", "Generating README.md file")
-  #   generate_readme(args.organization, args.license)
 
   if args.license:
     l.write_log("info", "Downloading LICENSE.md file")

--- a/bootstrap_repo.py
+++ b/bootstrap_repo.py
@@ -105,20 +105,15 @@ def generate_feature_request_template(logger, org):
     feat.close()
 
 def generate_readme(org, lic, repo):
+  readme_template = environment.get_template("readme.jinja2")
+  readme_vars = {
+    "org": org,
+    "lic": lic,
+    "repo": repo,
+  }
+  readme_content = readme_template.render(readme_vars)
   with open("output/README.md", "w") as readme:
-    readme.write(f"""
-![Github Actions](https://github.com/{org}/{repo}/actions/workflows/<action file name>.yml/badge.svg) ![GitHub License](https://img.shields.io/github/license/{org}/{repo}) ![Contributors](https://img.shields.io/github/contributors/{org}/{repo}) ![Issues](https://img.shields.io/github/issues/{org}/{repo}?color=0088ff) ![Pull Request](https://img.shields.io/github/issues-pr/{org}/{repo}?color=0088ff)
-
-# Repo Name
-
-## Description
-
-## Installation
-
-## Usage
-
-                 """)
-
+    readme.write(readme_content)
     readme.close()
 
 def generate_default_files(logger, org, lic, repo):

--- a/bootstrap_repo.py
+++ b/bootstrap_repo.py
@@ -164,26 +164,11 @@ def generate_default_files(logger, org, lic, repo):
     cc.write(coc_content)
     cc.close()
 
+  contrib_template = environment.get_template("contributing.jinja2")
+  contrib_vars = {}
+  contrib_content = contrib_template.render(contrib_vars)
   with open("output/CONTRIBUTING.md", "w") as c:
-    c.write("""
-## Development
-
-### Fork, Clone, Branch, and Create your Pull Request
-
-To Contribute to this repositiry please following the steps below. 
-
-1. Fork the repository if you have not already
-2. Clone your fork down locally to your machine
-3. Create and push a feature branch
-4. Make your changes and push them to your feature branch
-5. Open a pull request and include details of your change and any testing you have done in the pull request description. If possible please use [Conventional Commits](https://www.conventionalcommits.org/)
-            
-### Code Review
-
-We require all Pull Request to be revviewed by Code Owners in this repository. No Pull Request will be merged in to this repository without a code review. 
-
-Once your code has been reviewed and approved by the requisite number of team members, it will be merged into the main branch. Once merged, your PR will be automatically closed.
-            """)        
+    c.write(contrib_content)        
     c.close()
 
   with open("output/SUPPORT.md", "w") as support:

--- a/bootstrap_repo.py
+++ b/bootstrap_repo.py
@@ -185,15 +185,13 @@ def generate_default_files(logger, org, lic, repo):
     prt.write(pr_content)
     prt.close()
 
+  co_template = environment.get_template("codeowners.jinja2")
+  co_vars = {
+    "org": org,
+  }
+  co_content = co_template.render(co_vars)
   with open("output/CODEOWNERS.md", "w") as co:
-    co.write(f"""
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-* @{org}
-
-# For anything not explicitly taken by someone else:
-* @{org}/team-name
-            """)
+    co.write(co_content)
     co.close()
 
 def get_license(logger, license):

--- a/bootstrap_repo.py
+++ b/bootstrap_repo.py
@@ -211,19 +211,22 @@ def get_license(logger, license):
 
 def main():
   l=logs(os.path.basename(__file__))
-  l.write_log("info", "Script logger has been initialzied.")
-  args = get_args()
+  try:
+    l.write_log("info", "Script logger has been initialzied.")
+    args = get_args()
 
-  l.write_log("info", "Ensuring output directory exist")
-  if not os.path.exists("output"):
-    os.makedirs("output")
+    l.write_log("info", "Ensuring output directory exist")
+    if not os.path.exists("output"):
+      os.makedirs("output")
 
-  l.write_log("info", "Generating Default Files")
-  generate_default_files(l, args.organization, args.license, args.repo)
+    l.write_log("info", "Generating Default Files")
+    generate_default_files(l, args.organization, args.license, args.repo)
 
-  if args.license:
-    l.write_log("info", "Downloading LICENSE.md file")
-    get_license(l, args.license)
+    if args.license:
+      l.write_log("info", "Downloading LICENSE.md file")
+      get_license(l, args.license)
+  except Exception as e:
+    l.write_log("error", e)
 
 if __name__ == "__main__":
   try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ certifi==2024.2.2
 charset-normalizer==3.3.2
 idna==3.6
 path==16.10.0
+pathlib==1.0.1
 requests==2.31.0
 urllib3==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 certifi==2024.2.2
 charset-normalizer==3.3.2
 idna==3.6
+Jinja2==3.1.3
+MarkupSafe==2.1.5
 path==16.10.0
 pathlib==1.0.1
 requests==2.31.0

--- a/templates/bug.jinja2
+++ b/templates/bug.jinja2
@@ -1,0 +1,43 @@
+name: 🐛Bug Report
+description: File a bug report here
+title: "[BUG]: "
+labels: ["bug"]
+assignees: ["{{ org }}"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!!!
+  - type: checkboxes
+    id: new-bug
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Description of the bug
+      description: Tell us what bug you encountered and what should have happened
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: Please write the steps in a list form
+    validations:
+      required: true
+  - type: dropdown
+    id: versions
+    attributes:
+      label: Which version of the app are you using?
+      description: If this issue is occurring on more than 1 version of the app, select the appropriate versions.
+      multiple: true
+      options:
+       - 1.0.0
+    validations:
+      required: true

--- a/templates/changelog.jinja2
+++ b/templates/changelog.jinja2
@@ -1,0 +1,2 @@
+# Unreleased
+* initial repo creation

--- a/templates/code_of_conduct.jinja2
+++ b/templates/code_of_conduct.jinja2
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Be nice and respectful.

--- a/templates/codeowners.jinja2
+++ b/templates/codeowners.jinja2
@@ -1,0 +1,6 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+* @{{ org }}
+
+# For anything not explicitly taken by someone else:
+* @{{ org }}/team-name

--- a/templates/contributing.jinja2
+++ b/templates/contributing.jinja2
@@ -1,0 +1,17 @@
+## Development
+
+### Fork, Clone, Branch, and Create your Pull Request
+
+To Contribute to this repositiry please following the steps below. 
+
+1. Fork the repository if you have not already
+2. Clone your fork down locally to your machine
+3. Create and push a feature branch
+4. Make your changes and push them to your feature branch
+5. Open a pull request and include details of your change and any testing you have done in the pull request description. If possible please use [Conventional Commits](https://www.conventionalcommits.org/)
+            
+### Code Review
+
+We require all Pull Request to be revviewed by Code Owners in this repository. No Pull Request will be merged in to this repository without a code review. 
+
+Once your code has been reviewed and approved by the requisite number of team members, it will be merged into the main branch. Once merged, your PR will be automatically closed.

--- a/templates/feature_requests.jinja2
+++ b/templates/feature_requests.jinja2
@@ -1,0 +1,33 @@
+name: 🚀Feature request
+description: Suggest and idea for improvement
+title: "[Feat]: "
+labels: ["Enhancement"]
+assignees: ["{{ org }}"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!!!
+  - type: checkboxes
+    id: new-feature
+    attributes:
+      label: Is there an existing issue/feature for this?
+      description: Please search to see if an issue or feature request already exists for this.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Description of the feature
+      description: Tell us what this feature is about and what it will do.
+    validations:
+      required: true
+  - type: textarea
+    id: value
+    attributes:
+      label: What value will this feature add?
+      description: Provide examples of what value will be added by implementing the feature.
+      placeholder: Please write the values in a list form
+    validations:
+      required: true

--- a/templates/issue_config.jinja2
+++ b/templates/issue_config.jinja2
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Support
+    url: https://support.github.com/contact
+    about: Contact Support if you're having trouble with your GitHub account.

--- a/templates/pull_request_template.jinja2
+++ b/templates/pull_request_template.jinja2
@@ -1,0 +1,14 @@
+## Summary of the Pull Request
+
+## References and Relevant Issues
+
+## Detailed Description of the Pull Request / Additional comments
+
+## Validation Steps Performed
+
+## PR Checklist
+- [ ] Closes #xxx
+- [ ] Tests added/passed
+- [ ] Documentation updated
+   - If checked, please file a pull request and link it here: #xxx
+- [ ] Schema updated (if necessary)

--- a/templates/readme.jinja2
+++ b/templates/readme.jinja2
@@ -1,0 +1,11 @@
+![Github Actions](https://github.com/{{ org }}/{{ repo }}/actions/workflows/<action file name>.yml/badge.svg) ![GitHub License](https://img.shields.io/github/license/{{ org }}/{{ repo }}) ![Contributors](https://img.shields.io/github/contributors/{{ org }}/{{ repo }}) ![Issues](https://img.shields.io/github/issues/{{ org }}/{{ repo }}?color=0088ff) ![Pull Request](https://img.shields.io/github/issues-pr/{{ org }}/{{ repo }}?color=0088ff)
+
+# Repo Name
+
+## Description
+
+## Installation
+
+## Usage
+
+                 

--- a/templates/security.jinja2
+++ b/templates/security.jinja2
@@ -1,0 +1,33 @@
+## Security
+
+{{ org }} takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations.
+
+If you believe you have found a security vulnerability in any {{ org }}-owned repository, please report it to us as described below.
+
+## Reporting Security Issues
+            
+To report a security related issue, please open an issue on this repository and describe the details using the following template
+
+```
+# Security Vulnerability Description
+
+## Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+            
+## References to any CVE's
+            
+## Advanced Details
+### Files with security vulnerability
+
+### Location of impacted source code (if known)
+
+### Steps to reproduce issue
+            
+### Proof of concept of exploitation (if possible)
+            
+## Impact of Vulnerability
+
+```
+            
+## Preferred Languages
+
+We prefer all communications to be in English.

--- a/templates/support.jinja2
+++ b/templates/support.jinja2
@@ -1,0 +1,5 @@
+# Support
+
+## How to file issues and get help  
+
+This project uses [GitHub issues][gh-issue] to [track bugs][gh-bug] and [feature requests][gh-feature]. Please search the existing issues before filing new issues to avoid duplicates. For new topics, file your bug or feature request as a new issue.


### PR DESCRIPTION
## Summary of the Pull Request
Migrating all file contents to Jinja2 Templating

## References and Relevant Issues
N/A

## Detailed Description of the Pull Request / Additional comments
Instead of all file contents being hard coded in the `bootstrap-repo.py` script the file content have now been relocated to individual template files located in the `templates` directory. This allows for a smaller codebase in `bootstrap-repo.py` and allows for more flexibility in templating files. 

### Additional Changes
* The logic in the `main()` method was wrapped in a try/except statement to attempt to capture any exceptions and write them to the log file. 
* the `r` option was repurposed to be for repository name and generation of a README.md file was moved into `generate_default_files()`
* Added repo name to README.md templating
* Added jinja2 package to requirements.txt

## Validation Steps Performed
Script was ran loacally between each change to iteratively confirm changes performed as expected. 

## PR Checklist
- [X] Tests passed
- [X] Documentation updated
             